### PR TITLE
"Non-Context errors" fixes issue #10

### DIFF
--- a/access_list.go
+++ b/access_list.go
@@ -5,6 +5,15 @@ import (
 	"strings"
 )
 
+// AccessList Errors
+const (
+	ErrEmptyACLAction strError = "empty access list action"
+	ErrEmptyACLClaim  strError = "empty access list claim"
+	ErrEmptyClaim     strError = "empty claim value"
+	ErrEmptyValue     strError = "empty value"
+	ErrNoValues       strError = "no acl.Values"
+)
+
 // AccessListEntry represent an access list entry.
 type AccessListEntry struct {
 	Action string   `json:"action,omitempty"`
@@ -20,16 +29,16 @@ func NewAccessListEntry() *AccessListEntry {
 // Validate checks access list entry compliance
 func (acl *AccessListEntry) Validate() error {
 	if acl.Action == "" {
-		return fmt.Errorf("empty access list action")
+		return ErrEmptyACLAction
 	}
 	if acl.Action != "allow" && acl.Action != "deny" {
 		return fmt.Errorf("unsupported access list action: %s", acl.Action)
 	}
 	if acl.Claim == "" {
-		return fmt.Errorf("empty access list claim")
+		return ErrEmptyACLClaim
 	}
 	if len(acl.Values) == 0 {
-		return fmt.Errorf("no acl.Values")
+		return ErrNoValues
 	}
 	return nil
 }
@@ -49,7 +58,7 @@ func (acl *AccessListEntry) Deny() {
 // SetClaim sets claim value of an access list entry.
 func (acl *AccessListEntry) SetClaim(s string) error {
 	if s == "" {
-		return fmt.Errorf("empty claim value")
+		return ErrEmptyClaim
 	}
 	if s != "roles" {
 		return fmt.Errorf("access list does not support %s claim, only roles", s)
@@ -61,7 +70,7 @@ func (acl *AccessListEntry) SetClaim(s string) error {
 // AddValue adds value to an access list entry.
 func (acl *AccessListEntry) AddValue(s string) error {
 	if s == "" {
-		return fmt.Errorf("empty value")
+		return ErrEmptyValue
 	}
 	acl.Values = append(acl.Values, s)
 	return nil
@@ -70,7 +79,7 @@ func (acl *AccessListEntry) AddValue(s string) error {
 // SetValue sets value to an access list entry.
 func (acl *AccessListEntry) SetValue(arr []string) error {
 	if len(arr) == 0 {
-		return fmt.Errorf("empty value")
+		return ErrEmptyValue
 	}
 	acl.Values = arr
 	return nil

--- a/backend.go
+++ b/backend.go
@@ -2,12 +2,18 @@ package jwt
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
+
+	jwtlib "github.com/dgrijalva/jwt-go"
+)
+
+// Backend Errors
+const (
+	ErrInvalidSecretLength strError = "secrets less than 16 characters in length are not allowed"
 )
 
 // TokenBackend is the interface to provide key material.
 type TokenBackend interface {
-	ProvideKey(token *jwt.Token) (interface{}, error)
+	ProvideKey(token *jwtlib.Token) (interface{}, error)
 }
 
 // SecretKeyTokenBackend hold symentric keys from HS family.
@@ -18,7 +24,7 @@ type SecretKeyTokenBackend struct {
 // NewSecretKeyTokenBackend returns SecretKeyTokenBackend instance.
 func NewSecretKeyTokenBackend(s string) (*SecretKeyTokenBackend, error) {
 	if len(s) < 16 {
-		return nil, fmt.Errorf("secrets less than 16 characters in length are not allowed")
+		return nil, ErrInvalidSecretLength
 	}
 	b := &SecretKeyTokenBackend{
 		secret: []byte(s),
@@ -27,8 +33,8 @@ func NewSecretKeyTokenBackend(s string) (*SecretKeyTokenBackend, error) {
 }
 
 // ProvideKey provides key material from SecretKeyTokenBackend.
-func (b *SecretKeyTokenBackend) ProvideKey(token *jwt.Token) (interface{}, error) {
-	if _, validMethod := token.Method.(*jwt.SigningMethodHMAC); !validMethod {
+func (b *SecretKeyTokenBackend) ProvideKey(token *jwtlib.Token) (interface{}, error) {
+	if _, validMethod := token.Method.(*jwtlib.SigningMethodHMAC); !validMethod {
 		return nil, fmt.Errorf(
 			"signing method mismatch: HMAC (expected) vs. %v (received)",
 			token.Header["alg"],

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package jwt
+
+type strError string
+
+func (e strError) Error() string { return string(e) }

--- a/grantor.go
+++ b/grantor.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 )
 
+// Grantor Errors
+const (
+	ErrEmptySecret strError = "grantor token secret not configured"
+	ErrNoClaims    strError = "provided claims are nil"
+)
+
 // TokenGrantor creates and issues JWT tokens.
 type TokenGrantor struct {
 	CommonTokenConfig
@@ -18,7 +24,7 @@ func NewTokenGrantor() *TokenGrantor {
 // Validate check whether TokenGrantor has valid configuration.
 func (g *TokenGrantor) Validate() error {
 	if g.TokenSecret == "" {
-		return fmt.Errorf("grantor token secret not configured")
+		return ErrEmptySecret
 	}
 	return nil
 }
@@ -29,10 +35,10 @@ func (g *TokenGrantor) GrantToken(method string, claims *UserClaims) (string, er
 		return "", fmt.Errorf("grantor does not support %s token signing method", method)
 	}
 	if claims == nil {
-		return "", fmt.Errorf("provided claims are nil")
+		return "", ErrNoClaims
 	}
 	if g.TokenSecret == "" {
-		return "", fmt.Errorf("grantor token secret not configured")
+		return "", ErrEmptySecret
 	}
 	return claims.GetToken(method, []byte(g.TokenSecret))
 }

--- a/plugin.go
+++ b/plugin.go
@@ -1,14 +1,18 @@
 package jwt
 
 import (
-	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/caddyauth"
 	"go.uber.org/zap"
-	"net/http"
-	//"net/http/httputil"
-	"strings"
-	"sync"
+)
+
+// Plugin Errors
+const (
+	ErrProvisonFailed strError = "authorization provider provisioning error"
 )
 
 // ProviderPool is the global authorization provider pool.
@@ -86,7 +90,7 @@ func (m AuthProvider) Authenticate(w http.ResponseWriter, r *http.Request) (cadd
 	if m.ProvisionFailed {
 		w.WriteHeader(500)
 		w.Write([]byte(`Internal Server Error`))
-		return caddyauth.User{}, false, fmt.Errorf("authorization provider provisioning error")
+		return caddyauth.User{}, false, ErrProvisonFailed
 	}
 
 	if !m.Provisioned {

--- a/pool.go
+++ b/pool.go
@@ -2,10 +2,17 @@ package jwt
 
 import (
 	"fmt"
-	"go.uber.org/zap"
 	"os"
 	"strings"
 	"sync"
+
+	"go.uber.org/zap"
+)
+
+// Pool Errors
+const (
+	ErrEmptyProviderName strError = "authorization provider name is empty"
+	ErrNoMemberReference strError = "no member reference found"
 )
 
 // AuthProviderPool provides access to all instances of the plugin.
@@ -145,13 +152,13 @@ func (p *AuthProviderPool) Register(m *AuthProvider) error {
 // Provision provisions non-master instances in an authorization context.
 func (p *AuthProviderPool) Provision(name string) error {
 	if name == "" {
-		return fmt.Errorf("authorization provider name is empty")
+		return ErrEmptyProviderName
 	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.RefMembers == nil {
-		return fmt.Errorf("no member reference found")
+		return ErrNoMemberReference
 	}
 	m, exists := p.RefMembers[name]
 	if !exists {

--- a/provider.go
+++ b/provider.go
@@ -1,9 +1,10 @@
 package jwt
 
 import (
-	"github.com/satori/go.uuid"
 	"math/rand"
 	"strings"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 const tokenLifetime = 900

--- a/user.go
+++ b/user.go
@@ -4,9 +4,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	jwtlib "github.com/dgrijalva/jwt-go"
 	"strings"
 	"time"
+
+	jwtlib "github.com/dgrijalva/jwt-go"
+)
+
+// User Errors
+const (
+	ErrInvalidClaimExpiresAt strError = "invalid exp type"
+	ErrInvalidClaimIssuedAt  strError = "invalid iat type"
+	ErrInvalidClaimNotBefore strError = "invalid nbf type"
+	ErrInvalidSigningMethod  strError = "unsupported signing method"
+	ErrUnsupportedSecret     strError = "empty secrets are not supported"
 )
 
 var methods = map[string]bool{
@@ -106,7 +116,7 @@ func NewUserClaimsFromMap(m map[string]interface{}) (*UserClaims, error) {
 			v, _ := exp.Int64()
 			u.ExpiresAt = v
 		default:
-			return nil, fmt.Errorf("invalid exp type")
+			return nil, ErrInvalidClaimExpiresAt
 		}
 	}
 
@@ -122,7 +132,7 @@ func NewUserClaimsFromMap(m map[string]interface{}) (*UserClaims, error) {
 			v, _ := exp.Int64()
 			u.IssuedAt = v
 		default:
-			return nil, fmt.Errorf("invalid iat type")
+			return nil, ErrInvalidClaimIssuedAt
 		}
 	}
 
@@ -138,7 +148,7 @@ func NewUserClaimsFromMap(m map[string]interface{}) (*UserClaims, error) {
 			v, _ := exp.Int64()
 			u.NotBefore = v
 		default:
-			return nil, fmt.Errorf("invalid nbf type")
+			return nil, ErrInvalidClaimNotBefore
 		}
 	}
 
@@ -221,11 +231,11 @@ func (u *UserClaims) GetToken(method string, secret []byte) (string, error) {
 // GetToken returns a signed JWT token
 func GetToken(method string, secret []byte, claims UserClaims) (string, error) {
 	if _, exists := methods[method]; !exists {
-		return "", fmt.Errorf("unsupported signing method")
+		return "", ErrInvalidSigningMethod
 	}
 
 	if secret == nil {
-		return "", fmt.Errorf("empty secrets are not supported")
+		return "", ErrUnsupportedSecret
 	}
 
 	sm := jwtlib.GetSigningMethod(method)


### PR DESCRIPTION
Adds errors that don't have any context (or formatting rules) as
constants so that it's easy to use errors as values and see which errors
are possible via godocs.

Does slight cleanup by using `gofmt` on the files so they are formatted the standard go way.
Also uses the `jwtlib` alias for `"github.com/dgrijalva/jwt-go"` consistently.