### PR TITLE
Token order and Token Source updates

### DIFF
--- a/grantor_test.go
+++ b/grantor_test.go
@@ -47,7 +47,7 @@ func TestNewGrantor(t *testing.T) {
 	}
 	t.Logf("Granted Token: %s", token)
 
-	validator := NewTokenValidator(&AuthProvider{})
+	validator := NewTokenValidator()
 	validator.TokenSecret = secret
 	if err := validator.ConfigureTokenBackends(); err != nil {
 		t.Fatalf("validator backend configuration failed: %s", err)

--- a/grantor_test.go
+++ b/grantor_test.go
@@ -47,7 +47,7 @@ func TestNewGrantor(t *testing.T) {
 	}
 	t.Logf("Granted Token: %s", token)
 
-	validator := NewTokenValidator()
+	validator := NewTokenValidator(&AuthProvider{})
 	validator.TokenSecret = secret
 	if err := validator.ConfigureTokenBackends(); err != nil {
 		t.Fatalf("validator backend configuration failed: %s", err)

--- a/pool.go
+++ b/pool.go
@@ -62,7 +62,7 @@ func (p *AuthProviderPool) Register(m *AuthProvider) error {
 		p.Masters[m.Context] = m
 	}
 	if m.TokenValidator == nil {
-		m.TokenValidator = NewTokenValidator(m)
+		m.TokenValidator = NewTokenValidator()
 	}
 
 	if m.Master {
@@ -132,10 +132,13 @@ func (p *AuthProviderPool) Register(m *AuthProvider) error {
 			}
 		}
 
-		m.TokenValidator.TokenName = m.TokenName
+		if m.TokenName != "" {
+			m.TokenValidator.SetTokenName(m.TokenName)
+		}
 		m.TokenValidator.TokenSecret = m.TokenSecret
 		m.TokenValidator.TokenIssuer = m.TokenIssuer
 		m.TokenValidator.AccessList = m.AccessList
+		m.TokenValidator.TokenSources = m.AllowedTokenSources
 		if err := m.TokenValidator.ConfigureTokenBackends(); err != nil {
 			return ErrInvalidBackendConfiguration.WithArgs(m.Name, err)
 		}
@@ -239,13 +242,16 @@ func (p *AuthProviderPool) Provision(name string) error {
 	}
 
 	if m.TokenValidator == nil {
-		m.TokenValidator = NewTokenValidator(m)
+		m.TokenValidator = NewTokenValidator()
 	}
 
-	m.TokenValidator.TokenName = m.TokenName
+	if m.TokenName != "" {
+		m.TokenValidator.SetTokenName(m.TokenName)
+	}
 	m.TokenValidator.TokenSecret = m.TokenSecret
 	m.TokenValidator.TokenIssuer = m.TokenIssuer
 	m.TokenValidator.AccessList = m.AccessList
+	m.TokenValidator.TokenSources = m.AllowedTokenSources
 	if err := m.TokenValidator.ConfigureTokenBackends(); err != nil {
 		m.ProvisionFailed = true
 		return ErrInvalidBackendConfiguration.WithArgs(m.Name, err)

--- a/pool.go
+++ b/pool.go
@@ -62,7 +62,7 @@ func (p *AuthProviderPool) Register(m *AuthProvider) error {
 		p.Masters[m.Context] = m
 	}
 	if m.TokenValidator == nil {
-		m.TokenValidator = NewTokenValidator()
+		m.TokenValidator = NewTokenValidator(m)
 	}
 
 	if m.Master {
@@ -123,7 +123,7 @@ func (p *AuthProviderPool) Register(m *AuthProvider) error {
 		}
 
 		if len(m.AllowedTokenSources) == 0 {
-			m.AllowedTokenSources = []string{"header", "cookie", "query"}
+			m.AllowedTokenSources = allTokenSources
 		}
 
 		for _, ts := range m.AllowedTokenSources {
@@ -239,7 +239,7 @@ func (p *AuthProviderPool) Provision(name string) error {
 	}
 
 	if m.TokenValidator == nil {
-		m.TokenValidator = NewTokenValidator()
+		m.TokenValidator = NewTokenValidator(m)
 	}
 
 	m.TokenValidator.TokenName = m.TokenName

--- a/validator.go
+++ b/validator.go
@@ -24,16 +24,19 @@ const (
 	ErrInvalid             strError = "%v"
 )
 
-const tokenSourceHeader = "header"
-const tokenSourceCookie = "cookie"
-const tokenSourceQuery = "query"
+const (
+	tokenSourceHeader = "header"
+	tokenSourceCookie = "cookie"
+	tokenSourceQuery  = "query"
+)
 
-var allTokenSources []string
 var tokenSources = map[string]byte{
 	tokenSourceHeader: 0, // the value is the order they are in...
 	tokenSourceCookie: 1,
 	tokenSourceQuery:  2,
 }
+
+var allTokenSources []string
 
 func init() { // set the default token_sources up
 	allTokenSources = make([]string, len(tokenSources))
@@ -57,27 +60,30 @@ type TokenValidator struct {
 }
 
 // NewTokenValidator returns an instance of TokenValidator
-func NewTokenValidator(m *AuthProvider) *TokenValidator {
+func NewTokenValidator() *TokenValidator {
 	v := &TokenValidator{
 		AuthorizationHeaders: make(map[string]struct{}),
 		Cookies:              make(map[string]struct{}),
 		QueryParameters:      make(map[string]struct{}),
 	}
 
-	var tokenNames = defaultTokenNames
-	if m.TokenName != "" { // the default
-		tokenNames = []string{m.TokenName}
-	}
-
-	for _, name := range tokenNames {
+	for _, name := range defaultTokenNames {
 		v.AuthorizationHeaders[name] = struct{}{}
 		v.Cookies[name] = struct{}{}
 		v.QueryParameters[name] = struct{}{}
 	}
 
-	v.TokenSources = m.AllowedTokenSources
 	v.Cache = NewTokenCache()
 	return v
+}
+
+// SetTokenName sets the name of the token (i.e. <TokenName>=<JWT Token>)
+// this overrites the default token names
+func (v *TokenValidator) SetTokenName(name string) {
+	v.TokenName = name
+	v.AuthorizationHeaders = map[string]struct{}{name: struct{}{}}
+	v.Cookies = map[string]struct{}{name: struct{}{}}
+	v.QueryParameters = map[string]struct{}{name: struct{}{}}
 }
 
 // ConfigureTokenBackends configures available TokenBackend.

--- a/validator_test.go
+++ b/validator_test.go
@@ -104,20 +104,29 @@ func TestAuthorize(t *testing.T) {
 			expect:    true,
 		},
 		{
-			name:      "header with default sources and custom name check overwrite",
+			name:      "header with custom name check overwrite",
 			tokenName: "how_who_woh",
 			sources:   []string{tokenSourceHeader},
 			header:    []string{"access_token", newToken("apex")},
 			expect:    false,
 			err:       ErrNoTokenFound,
 		},
+		{
+			name:    "header with custom sources and no data where source is expected",
+			sources: []string{tokenSourceCookie},
+			header:  []string{"access_token", newToken("apex")},
+			expect:  false,
+			err:     nil,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			provider := &AuthProvider{TokenName: test.tokenName}
-			validator := NewTokenValidator(provider)
+			validator := NewTokenValidator()
 
+			if test.tokenName != "" {
+				validator.SetTokenName(test.tokenName)
+			}
 			validator.TokenSecret = secret
 			validator.TokenIssuer = "localhost"
 			validator.AccessList = []*AccessListEntry{entry}

--- a/validator_test.go
+++ b/validator_test.go
@@ -1,0 +1,157 @@
+package jwt
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func TestAuthorize(t *testing.T) {
+
+	entry := NewAccessListEntry()
+	entry.Allow()
+	if err := entry.SetClaim("roles"); err != nil {
+		t.Fatalf("default access list configuration error: %s", err)
+	}
+
+	for _, v := range []string{"anonymous", "guest"} {
+		if err := entry.AddValue(v); err != nil {
+			t.Fatalf("default access list configuration error: %s", err)
+		}
+	}
+
+	secret := "1234567890abcdef-ghijklmnopqrstuvwxyz"
+	newToken := func(scope string) string {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"exp":   time.Now().Add(10 * time.Minute).Unix(),
+			"iat":   time.Now().Add(10 * time.Minute * -1).Unix(),
+			"nbf":   time.Date(2015, 10, 10, 12, 0, 0, 0, time.UTC).Unix(),
+			"roles": "guest",
+			"org":   "somewhere",
+			"scope": scope,
+		})
+
+		tokenString, err := token.SignedString([]byte(secret))
+		if err != nil {
+			t.Fatalf("bad token signing: %v", err)
+		}
+
+		return tokenString
+	}
+
+	var tests = []struct {
+		name      string
+		tokenName string
+		sources   []string
+		header    []string
+		cookie    *http.Cookie
+		parameter []string
+		scope     string
+		expect    bool
+		err       error
+	}{
+		{
+			name:    "header with default sources and names",
+			scope:   "somewhere",
+			sources: allTokenSources,
+			header:  []string{"access_token", newToken("somewhere")},
+			expect:  true,
+		},
+		{
+			name:    "cookie with default sources and names",
+			scope:   "somewhere",
+			sources: allTokenSources,
+			cookie: &http.Cookie{
+				Name:  "access_token",
+				Value: newToken("somewhere"),
+			},
+			expect: true,
+		},
+		{
+			name:      "query with default sources and names",
+			scope:     "somewhere",
+			sources:   allTokenSources,
+			parameter: []string{"access_token", newToken("somewhere")},
+			expect:    true,
+		},
+		{
+			name:      "query over header and default names",
+			scope:     "cape",
+			sources:   []string{"query", "header"},
+			header:    []string{"access_token", newToken("boots")},
+			parameter: []string{"access_token", newToken("cape")},
+			expect:    true,
+		},
+		{
+			name:      "header with default sources and custom name",
+			tokenName: "how_who_woh",
+			scope:     "apex",
+			sources:   allTokenSources,
+			header:    []string{"how_who_woh", newToken("apex")},
+			expect:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &AuthProvider{TokenName: test.tokenName}
+			validator := NewTokenValidator(provider)
+
+			validator.TokenSecret = secret
+			validator.TokenIssuer = "localhost"
+			validator.AccessList = []*AccessListEntry{entry}
+			validator.TokenSources = test.sources
+
+			if err := validator.ConfigureTokenBackends(); err != nil {
+				t.Fatalf("validator backend configuration failed: %s", err)
+			}
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				u, got, err := validator.Authorize(r)
+
+				if got != test.expect {
+					t.Log(err)
+					t.Fatalf("got: %t expect: %t", got, test.expect)
+				}
+
+				if !errors.Is(err, test.err) {
+					t.Fatalf("got: %v expect: %v", err, test.err)
+				}
+
+				if u.Scope != test.scope {
+					t.Fatalf("got: %q expect: %q", u.Scope, test.scope)
+				}
+
+			}
+
+			req, err := http.NewRequest("GET", "/test/no/exists", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.header != nil && len(test.header) == 2 {
+				req.Header.Set("Authorization", fmt.Sprintf("%s=%s", test.header[0], test.header[1]))
+			}
+
+			if test.cookie != nil {
+				req.AddCookie(test.cookie)
+			}
+
+			if test.parameter != nil && len(test.parameter) == 2 {
+				q := req.URL.Query()
+				q.Set(test.parameter[0], test.parameter[1])
+				req.URL.RawQuery = q.Encode()
+			}
+
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			w.Result()
+		})
+	}
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -88,12 +88,28 @@ func TestAuthorize(t *testing.T) {
 			expect:    true,
 		},
 		{
+			name:      "query over header and both default names",
+			scope:     "cape",
+			sources:   []string{"query", "header"},
+			header:    []string{"access_token", newToken("boots")},
+			parameter: []string{"jwt_access_token", newToken("cape")},
+			expect:    true,
+		},
+		{
 			name:      "header with default sources and custom name",
 			tokenName: "how_who_woh",
 			scope:     "apex",
 			sources:   allTokenSources,
 			header:    []string{"how_who_woh", newToken("apex")},
 			expect:    true,
+		},
+		{
+			name:      "header with default sources and custom name check overwrite",
+			tokenName: "how_who_woh",
+			sources:   []string{tokenSourceHeader},
+			header:    []string{"access_token", newToken("apex")},
+			expect:    false,
+			err:       ErrNoTokenFound,
 		},
 	}
 
@@ -123,7 +139,7 @@ func TestAuthorize(t *testing.T) {
 					t.Fatalf("got: %v expect: %v", err, test.err)
 				}
 
-				if u.Scope != test.scope {
+				if len(test.scope) > 0 && u.Scope != test.scope {
 					t.Fatalf("got: %q expect: %q", u.Scope, test.scope)
 				}
 


### PR DESCRIPTION
Fix the handling of token source ordering so that it can be determined by the user of the library
Fix so that token sources can be removed
Fix so that a custom token name can be used and override the default names
Refactor error propagation so users of the library can see what is causing an error
Add a test to confirm the new code works as expected

Resolves: #13