### PR TITLE
small change to allow to redirect to current url

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ is not provided in the configuration, it can be passed via environment
 variable `JWT_TOKEN_SECRET`.
 
 The `auth_url_path` is the URL a user gets redirected to when a token is
-invalid.
+invalid.  If the value `CURRENT_URL` is found in the argument it is
+replaced with the url of the current request.
 
 The `access_list` is the series of entries defining how to authorize claims.
 In the above example, the plugin authorizes access for the holders of "roles"

--- a/plugin.go
+++ b/plugin.go
@@ -116,7 +116,8 @@ func (m AuthProvider) Authenticate(w http.ResponseWriter, r *http.Request) (cadd
 		for k := range m.TokenValidator.Cookies {
 			w.Header().Add("Set-Cookie", k+"=delete; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT")
 		}
-		w.Header().Set("Location", m.AuthURLPath)
+		path := strings.ReplaceAll(m.AuthURLPath, "CURRENT_URL", r.URL.String())
+		w.Header().Set("Location", path)
 		w.WriteHeader(302)
 		w.Write([]byte(`Unauthorized`))
 		return caddyauth.User{}, false, err
@@ -129,7 +130,8 @@ func (m AuthProvider) Authenticate(w http.ResponseWriter, r *http.Request) (cadd
 		for k := range m.TokenValidator.Cookies {
 			w.Header().Add("Set-Cookie", k+"=delete; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT")
 		}
-		w.Header().Set("Location", m.AuthURLPath)
+		path := strings.ReplaceAll(m.AuthURLPath, "CURRENT_URL", r.URL.String())
+		w.Header().Set("Location", path)
 		w.WriteHeader(302)
 		w.Write([]byte(`Unauthorized User`))
 		return caddyauth.User{}, false, nil
@@ -143,7 +145,8 @@ func (m AuthProvider) Authenticate(w http.ResponseWriter, r *http.Request) (cadd
 		for k := range m.TokenValidator.Cookies {
 			w.Header().Add("Set-Cookie", k+"=delete; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT")
 		}
-		w.Header().Set("Location", m.AuthURLPath)
+		path := strings.ReplaceAll(m.AuthURLPath, "CURRENT_URL", r.URL.String())
+		w.Header().Set("Location", path)
 		w.WriteHeader(302)
 		w.Write([]byte(`User Unauthorized`))
 		return caddyauth.User{}, false, nil


### PR DESCRIPTION
You can now set the following auth_url:
```
auth_url /auth?redirect_url=CURRENT_URL
```

And it will substitute the text CURRENT_URL with the current request.URL.  This allows you to be redirected to the original page you were trying to get to before you were redirected to auth.