### PR TITLE
Add header with userid

### DIFF
--- a/pkg/auth/authorizer.go
+++ b/pkg/auth/authorizer.go
@@ -223,13 +223,19 @@ func (m Authorizer) Authenticate(w http.ResponseWriter, r *http.Request, upstrea
 		}
 	}
 
+	if userClaims.ID != "" {
+		userIdentity["id"] = userClaims.ID
+		if m.PassClaimsWithHeaders {
+			r.Header.Set("X-Token-User-ID", userClaims.ID)
+		}
+	}
+	
 	if userClaims.Name != "" {
 		userIdentity["name"] = userClaims.Name
 		if m.PassClaimsWithHeaders {
 			r.Header.Set("X-Token-User-Name", userClaims.Name)
 		}
 	}
-
 	if userClaims.Email != "" {
 		userIdentity["email"] = userClaims.Email
 		if m.PassClaimsWithHeaders {


### PR DESCRIPTION
So... I didn't test this, but seems pretty simple. Would be nice to have have a header I can pass to other reverse proxied applications that includes the user id. Whereas the name is the user's full name when I'm authing vs. oauth, the id will be their UID in ldap, which is what I want to use an a unique identifier