### PR TITLE
feature: Implement caddyfile.Unmarshaler interface

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -34,7 +34,7 @@ import (
 const badRepl string = "ERROR_BAD_REPL"
 
 func init() {
-	httpcaddyfile.RegisterHandlerDirective("jwt", parseCaddyfile)
+	httpcaddyfile.RegisterHandlerDirective("jwt", getMiddlewareFromParseCaddyfile)
 }
 
 // parseCaddyfile sets up JWT token authorization plugin. Syntax:
@@ -93,7 +93,7 @@ func init() {
 //       inject headers with claims
 //     }
 //
-func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+func parseCaddyfile(h httpcaddyfile.Helper) (*authz.Authorizer, error) {
 	var cryptoKeyConfig []string
 	p := authz.Authorizer{
 		PrimaryInstance:  false,
@@ -353,9 +353,18 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 		p.CryptoKeyConfigs = configs
 	}
 
+	return &p, nil
+}
+
+func getMiddlewareFromParseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+	p, err := parseCaddyfile(h)
+	if err != nil {
+		return nil, err
+	}
+
 	return caddyauth.Authentication{
 		ProvidersRaw: caddy.ModuleMap{
-			"jwt": caddyconfig.JSON(AuthMiddleware{Authorizer: &p}, nil),
+			"jwt": caddyconfig.JSON(AuthMiddleware{Authorizer: p}, nil),
 		},
 	}, nil
 }

--- a/plugin.go
+++ b/plugin.go
@@ -16,6 +16,8 @@ package jwt
 
 import (
 	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp/caddyauth"
 	"github.com/greenpau/caddy-auth-jwt/pkg/authz"
@@ -46,6 +48,19 @@ func (m *AuthMiddleware) Provision(ctx caddy.Context) error {
 	opts := make(map[string]interface{})
 	opts["logger"] = ctx.Logger(m)
 	return m.Authorizer.Provision(opts)
+}
+
+// UnmarshalCaddyfile unmarshals a caddyfile
+func (m *AuthMiddleware) UnmarshalCaddyfile(d *caddyfile.Dispenser) (err error) {
+
+	authorizer, err := parseCaddyfile(httpcaddyfile.Helper{Dispenser: d})
+	if err != nil {
+		return err
+	}
+
+	m.Authorizer = authorizer
+
+	return nil
 }
 
 // Validate implements caddy.Validator.
@@ -83,6 +98,7 @@ var (
 	_ caddy.Provisioner       = (*AuthMiddleware)(nil)
 	_ caddy.Validator         = (*AuthMiddleware)(nil)
 	_ caddyauth.Authenticator = (*AuthMiddleware)(nil)
+	_ caddyfile.Unmarshaler   = (*AuthMiddleware)(nil)
 )
 
 // GetRequestID returns request ID.


### PR DESCRIPTION
I hereby consent to the Individual CLA provided in assets/cla/individual_cla.md

This PR brings the implementation of the caddyfile.Unmarshaler interface,
adding the possibility for other modules to use caddyfile.UnmarshalModule()
and to instantiate a new authz.Authorizer from the Caddyfile configuration format.